### PR TITLE
Plex-Media-Server指纹格式错误

### DIFF
--- a/whatweb/plex-media-server.json
+++ b/whatweb/plex-media-server.json
@@ -8,12 +8,12 @@
         {
             "name": "X-Plex-Protocol header",
             "text": "",
-            "search": "header[X-Plex-Protocol]"
+            "search": "headers[X-Plex-Protocol]"
         },
         {
             "name": "X-Plex-Content-Original-Length header",
             "text": "",
-            "search": "header[X-Plex-Content-Original-Length]"
+            "search": "headers[X-Plex-Content-Original-Length]"
         },
         {
             "name": "XML MediaGrabber tag",


### PR DESCRIPTION
第11行和16行  应该是headers